### PR TITLE
Add quotation marks around cd for OSes that have spaces in appdirs.

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -467,7 +467,7 @@ def download_geoip_data():
 
     if download:
         logging.info("Downloading GeoIP.dat")
-        cmd = "cd {}; wget -N -q http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz; gzip -dfq GeoIP.dat.gz".format(config.DATA_DIR)
+        cmd = "cd '{}'; wget -N -q http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz; gzip -dfq GeoIP.dat.gz".format(config.DATA_DIR)
         subprocess_cmd(cmd)
     else:
         logging.info("GeoIP.dat OK")


### PR DESCRIPTION
Mac OS X's usual appdir has a space in it "Application Support" and breaks the download of GeoIP. Quick, trivial fix, so that it can properly cd to the app dir.
