### PR TITLE
Don't display empty debits and credits in history

### DIFF
--- a/counterblock/lib/processor/api.py
+++ b/counterblock/lib/processor/api.py
@@ -198,7 +198,8 @@ def serve_api():
             }, abort_on_error=True)['result']
         
         address_dict['debits'] = util.call_jsonrpc_api("get_debits",
-            { 'filters': [{'field': 'address', 'op': '==', 'value': address},],
+            { 'filters': [{'field': 'address', 'op': '==', 'value': address},
+                          {'field': 'quantity', 'op': '>', 'value': 0}],
               'order_by': 'block_index',
               'order_dir': 'asc',
               'start_block': start_block,
@@ -206,7 +207,8 @@ def serve_api():
             }, abort_on_error=True)['result']
         
         address_dict['credits'] = util.call_jsonrpc_api("get_credits",
-            { 'filters': [{'field': 'address', 'op': '==', 'value': address},],
+            { 'filters': [{'field': 'address', 'op': '==', 'value': address},
+                          {'field': 'quantity', 'op': '>', 'value': 0}],
               'order_by': 'block_index',
               'order_dir': 'asc',
               'start_block': start_block,


### PR DESCRIPTION
Fixes the slightly illogical 0 XCP debit shown after creation of a free token (CounterpartyXCP/counterwallet#660).