### PR TITLE
Add modules.conf for regtest, testnet in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN python3 setup.py develop
 
 COPY docker/server.conf /root/.config/counterblock/server.conf
 COPY docker/modules.conf /root/.config/counterblock/modules.conf
+COPY docker/modules.conf /root/.config/counterblock/modules.testnet.conf
+COPY docker/modules.conf /root/.config/counterblock/modules.regtest.conf
 COPY docker/counterwallet.conf /root/.config/counterblock/counterwallet.conf
 COPY docker/start.sh /usr/local/bin/start.sh
 RUN chmod a+x /usr/local/bin/start.sh


### PR DESCRIPTION
When trying to work "counterblock" with "regtest" or "testnet" mode, there was a case where I forgot to make "modules.conf" and could not use the API I want to use.
So I add "modules.conf" of "regtest, testnet" process in "Dockerfile"